### PR TITLE
Cleared out unnecessary typedefs that confused the VC++ Compiler

### DIFF
--- a/DataVisualizer/visualizer.cpp
+++ b/DataVisualizer/visualizer.cpp
@@ -4,7 +4,7 @@
 // that can be used across various datastructures.
 #include <visualizer.h>
 
-Ui::List::list(QGraphicsView *v, QGraphicsScene *s,
+Ui::List::List(QGraphicsView *v, QGraphicsScene *s,
            QRectF coords, QPointF lP, QLineF lL, QString val)
 {
     view = v;
@@ -23,7 +23,7 @@ Ui::List::list(QGraphicsView *v, QGraphicsScene *s,
     lLabelCoords = lP;
 }
 
-Ui::List::~list()
+Ui::List::~List()
 {
     if (lLabel)
        delete lLabel;

--- a/DataVisualizer/visualizer.h
+++ b/DataVisualizer/visualizer.h
@@ -31,7 +31,7 @@ namespace Ui {
        QPointF *pos;
    } EllipseElement;
 
-   class list {
+   class List {
    private:
        QGraphicsScene *scene;
        QGraphicsView *view;
@@ -44,9 +44,9 @@ namespace Ui {
        std::map<int, Ui::RectElement> lMap;
        QRectF sceneCoords, baseCoords;
    public:
-       list() { numEntries=0; }
-       ~list();
-       explicit list(QGraphicsView *view, QGraphicsScene *scene,
+       List() { numEntries=0; }
+       ~List();
+       explicit List(QGraphicsView *view, QGraphicsScene *scene,
                      QRectF coords, QPointF lP, QLineF lL, QString val);
        void insertNode();
        void removeNode();
@@ -60,7 +60,6 @@ namespace Ui {
        QString getDataStr(int idx) { return (listData[idx]); }
        void setData(int idx, QString val) { listData[idx] = val; }
    };
-   typedef class list List;
 
    class binaryTree {
    private:
@@ -90,8 +89,6 @@ namespace Ui {
        void setData(int idx, QString val) { if (idx < MAX_ENTRIES) { treeData[idx] = val;} }
 
    };
-   typedef class binaryTree binaryTree;
-
 }
 
 #endif // VISUALIZER_H


### PR DESCRIPTION
It seems when building in QtCreator using Desktop Qt 5.7.0
MSVC2015_64bit the typedefs for the binaryTree and list classes
are breaking the build. Removing the typedefs and uppercasing the list
class to List fixes the issues. Besides the successful build removing
these typedefs is stylistically more appropriate in c++ and
stylistically more consistent overall. Why lowercase the list class
if you will immediately typedef it to uppercase?
